### PR TITLE
Rename effective price helper and unify dutch book EV signature

### DIFF
--- a/backend/app/tasks_analysis.py
+++ b/backend/app/tasks_analysis.py
@@ -107,7 +107,7 @@ def _stale_penalty_bps(age_sec: Optional[float]) -> float:
     steps = min(10, math.ceil((age_sec - 60) / 60.0))
     return 5.0 * steps
 
-def _effective_price(price_mid: float, size_usd: float, taker_bps: float, age_sec: Optional[float]) -> float:
+def _leg_effective_price(price_mid: float, size_usd: float, taker_bps: float, age_sec: Optional[float]) -> float:
     p = _slippage_mid_to_fill(price_mid, size_usd)
     fee = _bps_to_frac(taker_bps)
     stale = _bps_to_frac(_stale_penalty_bps(age_sec))
@@ -224,8 +224,8 @@ def _build_dutch_book(group: Dict[str, Any], fees_map: Dict[str, Dict[str, float
             # We’ll store one row per size bucket (to fit your schema: one EV per row)
             for size in size_candidates:
                 sz = min(size, float(fill_usd))
-                yes_eff = _effective_price(a["yes_mid"], sz, taker_a, age_a)
-                no_eff  = _effective_price(b["no_mid"],  sz, taker_b, age_b)
+                yes_eff = _leg_effective_price(a["yes_mid"], sz, taker_a, age_a)
+                no_eff  = _leg_effective_price(b["no_mid"],  sz, taker_b, age_b)
                 ev_usd, edge_bps = _dutch_book_ev(yes_eff, no_eff, sz)
                 if ev_usd <= 0:
                     continue

--- a/backend/tests/test_ev_math.py
+++ b/backend/tests/test_ev_math.py
@@ -1,4 +1,4 @@
-from app.tasks_analysis import _leg_effective_price, _dutch_book_ev, _bps_to_frac
+from app.tasks_analysis import _leg_effective_price, _dutch_book_ev
 
 def test_leg_effective_price_monotonic():
     p = 0.60
@@ -9,16 +9,11 @@ def test_leg_effective_price_monotonic():
 
 def test_dutch_book_simple():
     # YES=0.65 on A, NO=0.40 on B at small size, tiny fees, no staleness
-    legs = [
-        {"effective_price": 0.65},
-        {"effective_price": 0.40},
-    ]
-    ev, bps = _dutch_book_ev(legs, size_usd=100.0)
+    ev, bps = _dutch_book_ev(0.65, 0.40, size_usd=100.0)
     # worst-case profit = min(100*(1-0.65)-100*0.40, 100*(1-0.40)-100*0.65) = min(-5, -5) = -5
     # That’s negative → not an arb unless prices are better (e.g., 0.55 + 0.40)
     assert ev <= 0
     # adjust to true Dutch: 0.55 + 0.40 = 0.95
-    legs = [{"effective_price": 0.55}, {"effective_price": 0.40}]
-    ev, bps = _dutch_book_ev(legs, 100.0)
+    ev, bps = _dutch_book_ev(0.55, 0.40, 100.0)
     assert ev > 0
     assert bps > 0


### PR DESCRIPTION
## Summary
- rename `_effective_price` to `_leg_effective_price`
- keep `_dutch_book_ev` signature `(yes_eff, no_eff, size_usd)` and update tests accordingly

## Testing
- `export SUPABASE_URL='https://example.com'`
- `export SUPABASE_SERVICE_ROLE='service_role'`
- `PYTHONPATH=backend pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d4c34cc483269a2c2bcec09d2826