### PR TITLE
fix: correct tasks import name

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -80,7 +80,7 @@ celery.conf.update(
     imports=[
         "app.tasks",              # heartbeat
         "app.tasks_ingest",       # fetch_markets, write_markets, write_snapshots
-        "app.tasks_embedding",    # embeddings.embed_new_markets
+        "app.tasks_embeddings",   # embeddings.embed_new_markets
         "app.tasks_grouping",     # grouping.recompute_all / recompute_for_market
         "app.tasks_analysis",     # analysis.compute_opportunities   <-- added
     ],


### PR DESCRIPTION
## Summary
- fix Celery imports to use `app.tasks_embeddings`

## Testing
- `python -m pytest -q` *(fails: ImportError: cannot import name '_leg_effective_price')*
- `python -m pytest tests/test_dao.py tests/test_grouping_eval.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d556459c8326b708fce7a1d96f86