### PR TITLE
docs: add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ Goal: A runnable monorepo skeleton including:
 - DigitalOcean App spec and CI stubs
 - Shared env vars and dev scripts wired
 
+Architecture
+------------
+
+See [docs/architecture.md](docs/architecture.md) for a high-level diagram.
+
+Components:
+
+- **Backend**: FastAPI service providing the API.
+- **Celery workers**: asynchronous task executors used by the backend.
+- **Supabase**: Postgres database and authentication layer.
+- **Redis**: cache and message broker connecting the backend and workers.
+- **Bot**: Telegram bot server interfacing with the backend and webapp.
+- **Webapp**: React-based Telegram WebApp frontend.
+
 Quick Start
 -----------
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+# Architecture
+
+```mermaid
+graph LR
+    webapp[Webapp] --> backend[Backend]
+    bot[Bot] --> backend
+    backend --> supabase[Supabase]
+    backend --> redis[Redis]
+    backend --> workers[Celery Workers]
+    workers --> redis
+    workers --> supabase
+```


### PR DESCRIPTION
## Summary
- add docs folder with mermaid-based architecture diagram
- document backend, workers, supabase, redis, bot, and webapp in README

## Testing
- `SUPABASE_URL="http://example" SUPABASE_SERVICE_ROLE="dummy" PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4d997e9f483268597f529a7724543