### PR TITLE
feat: add polymarket and limitless fetchers

### DIFF
--- a/backend/exchanges/__init__.py
+++ b/backend/exchanges/__init__.py
@@ -1,0 +1,5 @@
+from .polymarket import PolymarketExchange
+from .limitless import LimitlessExchange
+from .base import BaseExchange
+
+__all__ = ["PolymarketExchange", "LimitlessExchange", "BaseExchange"]

--- a/backend/exchanges/base.py
+++ b/backend/exchanges/base.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+import redis
+import requests
+
+
+class BaseExchange(ABC):
+    """Minimal base class for exchange fetchers.
+
+    Provides a shared :class:`requests.Session` and a redis-backed rate
+    limiter used by subclasses.  The limiter implements a very small token
+    bucket that ensures we do not exceed ``limit`` requests within ``period``
+    seconds.  Subclasses should call :meth:`_acquire_token` before making any
+    outbound request.
+    """
+
+    platform: str = ""
+    base_url: str = ""
+
+    def __init__(self, redis_client: redis.Redis | None = None) -> None:
+        self.session = requests.Session()
+        # Connecting to redis is lazy; this will not fail when redis is not
+        # running which keeps unit tests lightweight.
+        self.redis = redis_client or redis.Redis.from_url(
+            os.getenv("REDIS_URL", "redis://localhost:6379/0"), decode_responses=True
+        )
+
+    # ------------------------------------------------------------------
+    # Rate limiting helpers
+    # ------------------------------------------------------------------
+    def _acquire_token(self, key: str, limit: int, period: int) -> None:
+        """Acquire a rate limit token.
+
+        This uses a simple counter in redis with an expiry ``period``.  If the
+        counter already reached ``limit`` we sleep until the key expires and
+        retry.
+        """
+
+        redis_key = f"rl:{self.platform}:{key}"
+        while True:
+            try:
+                with self.redis.pipeline() as pipe:
+                    pipe.watch(redis_key)
+                    current = pipe.get(redis_key)
+                    current_val = int(current) if current else 0
+                    if current_val < limit:
+                        pipe.multi()
+                        if current_val == 0:
+                            pipe.set(redis_key, 1, ex=period)
+                        else:
+                            pipe.incr(redis_key)
+                        pipe.execute()
+                        return
+                # Limit hit; wait for the key to expire
+                time.sleep(period)
+            except redis.WatchError:
+                # Retry on race conditions
+                continue
+
+    # ------------------------------------------------------------------
+    # Interface to implement
+    # ------------------------------------------------------------------
+    @abstractmethod
+    def fetch_active_markets(self) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetch_orderbook_or_amm_params(self, market_id: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def normalize_market(self, raw: Dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def normalize_snapshot(self, market_id: str, raw: Dict[str, Any]) -> Any:
+        raise NotImplementedError

--- a/backend/exchanges/limitless.py
+++ b/backend/exchanges/limitless.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from .base import BaseExchange
+from app.types import MarketNormalized, SnapshotNormalized, OutcomeQuote
+
+
+class LimitlessExchange(BaseExchange):
+    """Exchange adapter for the Limitless platform."""
+
+    platform = "limitless"
+    base_url = "https://api.limitless.exchange"
+
+    def fetch_active_markets(self) -> List[Dict[str, Any]]:
+        """Fetch list of active markets from Limitless."""
+
+        self._acquire_token("markets", limit=5, period=1)
+        resp = self.session.get(f"{self.base_url}/v1/markets", params={"status": "active"})
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_orderbook_or_amm_params(self, market_id: str) -> Dict[str, Any]:
+        """Fetch orderbook/AMM parameters for a market."""
+
+        self._acquire_token("orderbook", limit=5, period=1)
+        resp = self.session.get(f"{self.base_url}/v1/markets/{market_id}/orderbook")
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Normalization helpers
+    # ------------------------------------------------------------------
+    def normalize_market(self, raw: Dict[str, Any]) -> MarketNormalized:
+        outcomes = []
+        for out in raw.get("outcomes", []):
+            outcomes.append(
+                {
+                    "outcome_id": str(out.get("id")),
+                    "label": out.get("name") or out.get("title"),
+                    "prob": _to_float(out.get("prob")),
+                }
+            )
+
+        end_date = _parse_date(raw.get("resolveDate") or raw.get("end_date"))
+        return MarketNormalized(
+            platform=self.platform,
+            event_id=str(raw.get("id")),
+            title=raw.get("question") or raw.get("title", ""),
+            description=raw.get("description"),
+            end_date=end_date,
+            status=raw.get("status"),
+            volume_usd=_to_float(raw.get("volume")),
+            liquidity_usd=_to_float(raw.get("liquidity")),
+            outcomes=outcomes,
+            metadata={"category": raw.get("category")},
+            raw=raw,
+        )
+
+    def normalize_snapshot(self, market_id: str, raw: Dict[str, Any]) -> SnapshotNormalized:
+        ts_raw = raw.get("timestamp") or raw.get("ts")
+        if isinstance(ts_raw, (int, float)):
+            ts = datetime.fromtimestamp(ts_raw, tz=timezone.utc)
+        else:
+            ts = datetime.now(tz=timezone.utc)
+
+        outcomes: List[OutcomeQuote] = []
+        for out in raw.get("outcomes", []):
+            outcomes.append(
+                OutcomeQuote(
+                    outcome_id=str(out.get("id")),
+                    label=out.get("name") or out.get("label"),
+                    bid=_to_float(out.get("bid")),
+                    ask=_to_float(out.get("ask")),
+                    prob=_to_float(out.get("prob")),
+                    max_fill=_to_float(out.get("liquidity")),
+                    depth=out.get("depth"),
+                )
+            )
+
+        return SnapshotNormalized(
+            market_event_id=str(market_id),
+            ts=ts,
+            outcomes=outcomes,
+            price_source="orderbook",
+            liquidity_usd=_to_float(raw.get("liquidity")),
+            fees=raw.get("fees"),
+            stale_seconds=None,
+        )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+def _parse_date(s: Any) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _to_float(val: Any) -> float | None:
+    try:
+        if val is None:
+            return None
+        return float(val)
+    except Exception:
+        return None

--- a/backend/exchanges/polymarket.py
+++ b/backend/exchanges/polymarket.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from .base import BaseExchange
+from app.types import MarketNormalized, SnapshotNormalized, OutcomeQuote
+
+
+class PolymarketExchange(BaseExchange):
+    """Exchange adapter for the Polymarket platform."""
+
+    platform = "polymarket"
+    base_url = "https://clob.polymarket.com"
+
+    def fetch_active_markets(self) -> List[Dict[str, Any]]:
+        """Fetch list of active markets from Polymarket.
+
+        Returns the raw JSON payload from the API.
+        """
+
+        self._acquire_token("markets", limit=5, period=1)
+        resp = self.session.get(f"{self.base_url}/markets", params={"active": "true"})
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_orderbook_or_amm_params(self, market_id: str) -> Dict[str, Any]:
+        """Fetch the orderbook for a given market."""
+
+        self._acquire_token("orderbook", limit=5, period=1)
+        resp = self.session.get(f"{self.base_url}/markets/{market_id}/orderbook")
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Normalization helpers
+    # ------------------------------------------------------------------
+    def normalize_market(self, raw: Dict[str, Any]) -> MarketNormalized:
+        outcomes = []
+        for out in raw.get("outcomes", []):
+            outcomes.append(
+                {
+                    "outcome_id": str(out.get("id") or out.get("token_id")),
+                    "label": out.get("name") or out.get("title"),
+                    "prob": _to_float(out.get("price")),
+                }
+            )
+
+        end_date = _parse_date(raw.get("end_date") or raw.get("endDate"))
+        status = raw.get("status")
+        if status is None:
+            status = "resolved" if raw.get("isResolved") else "open"
+
+        return MarketNormalized(
+            platform=self.platform,
+            event_id=str(raw.get("id")),
+            title=raw.get("question") or raw.get("title", ""),
+            description=raw.get("description"),
+            end_date=end_date,
+            status=status,
+            volume_usd=_to_float(raw.get("volume")),
+            liquidity_usd=_to_float(raw.get("liquidity")),
+            outcomes=outcomes,
+            metadata={"slug": raw.get("slug")},
+            raw=raw,
+        )
+
+    def normalize_snapshot(self, market_id: str, raw: Dict[str, Any]) -> SnapshotNormalized:
+        ts = datetime.now(tz=timezone.utc)
+        outcomes: List[OutcomeQuote] = []
+        for out in raw.get("outcomes", []):
+            outcomes.append(
+                OutcomeQuote(
+                    outcome_id=str(out.get("id")),
+                    label=out.get("name") or out.get("label"),
+                    bid=_to_float(out.get("bid")),
+                    ask=_to_float(out.get("ask")),
+                    prob=_to_float(out.get("price") or out.get("prob")),
+                    max_fill=_to_float(out.get("max_qty") or out.get("maxQty")),
+                    depth=out.get("depth"),
+                )
+            )
+
+        return SnapshotNormalized(
+            market_event_id=str(market_id),
+            ts=ts,
+            outcomes=outcomes,
+            price_source="orderbook",
+            liquidity_usd=_to_float(raw.get("liquidity")),
+            fees=raw.get("fees"),
+            stale_seconds=None,
+        )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+def _parse_date(s: Any) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+def _to_float(val: Any) -> float | None:
+    try:
+        if val is None:
+            return None
+        return float(val)
+    except Exception:
+        return None

--- a/backend/tests/test_fetcher_normalization.py
+++ b/backend/tests/test_fetcher_normalization.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from exchanges.polymarket import PolymarketExchange
+from exchanges.limitless import LimitlessExchange
+from app.types import MarketNormalized, SnapshotNormalized, OutcomeQuote
+
+
+def test_polymarket_normalization():
+    raw_market = {
+        "id": "pm1",
+        "question": "Will it rain tomorrow?",
+        "description": "Weather forecast",
+        "endDate": "2024-12-31T00:00:00Z",
+        "slug": "rain-tomorrow",
+        "volume": "1234.5",
+        "liquidity": "1000",
+        "outcomes": [
+            {"id": "0", "name": "YES", "price": 0.6},
+            {"id": "1", "name": "NO", "price": 0.4},
+        ],
+        "isResolved": False,
+    }
+    ex = PolymarketExchange()
+    m = ex.normalize_market(raw_market)
+    assert isinstance(m, MarketNormalized)
+    assert m.platform == "polymarket"
+    assert m.event_id == "pm1"
+    assert len(m.outcomes) == 2
+    assert m.outcomes[0]["label"] == "YES"
+
+    raw_snapshot = {
+        "outcomes": [
+            {"id": "0", "name": "YES", "bid": "0.59", "ask": "0.61", "price": 0.6, "max_qty": 100},
+            {"id": "1", "name": "NO", "bid": 0.39, "ask": 0.41, "price": 0.4, "max_qty": 110},
+        ],
+        "liquidity": 500,
+        "fees": {"maker": 0.02},
+    }
+    snap = ex.normalize_snapshot("pm1", raw_snapshot)
+    assert isinstance(snap, SnapshotNormalized)
+    assert snap.market_event_id == "pm1"
+    assert len(snap.outcomes) == 2
+    assert isinstance(snap.outcomes[0], OutcomeQuote)
+    assert snap.outcomes[0].bid == 0.59
+
+
+def test_limitless_normalization():
+    raw_market = {
+        "id": "ll1",
+        "question": "Will Team A win?",
+        "description": "Sports",
+        "resolveDate": "2024-10-01T12:00:00Z",
+        "status": "trading",
+        "volume": 200,
+        "liquidity": 150,
+        "category": "sports",
+        "outcomes": [
+            {"id": "0", "name": "YES", "prob": 0.55},
+            {"id": "1", "name": "NO", "prob": 0.45},
+        ],
+    }
+    ex = LimitlessExchange()
+    m = ex.normalize_market(raw_market)
+    assert isinstance(m, MarketNormalized)
+    assert m.platform == "limitless"
+    assert m.event_id == "ll1"
+    assert m.status == "trading"
+    assert len(m.outcomes) == 2
+
+    raw_snapshot = {
+        "timestamp": 1700000000,
+        "outcomes": [
+            {"id": "0", "name": "YES", "bid": 0.54, "ask": 0.56, "prob": 0.55, "liquidity": 80},
+            {"id": "1", "name": "NO", "bid": 0.44, "ask": 0.46, "prob": 0.45, "liquidity": 90},
+        ],
+        "liquidity": 160,
+        "fees": {"taker": 0.03},
+    }
+    snap = ex.normalize_snapshot("ll1", raw_snapshot)
+    assert isinstance(snap, SnapshotNormalized)
+    assert snap.market_event_id == "ll1"
+    assert len(snap.outcomes) == 2
+    assert snap.outcomes[1].ask == 0.46


### PR DESCRIPTION
## Summary
- implement BaseExchange with redis token bucket rate limiting
- add Polymarket and Limitless exchange adapters with market and snapshot normalization
- add unit tests validating normalization for both exchanges

## Testing
- `PYTHONPATH=. pytest tests/test_fetcher_normalization.py`
- `PYTHONPATH=. pytest` *(fails: SUPABASE_URL field required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da7019248326a9c1be7d02976ea5