### PR TITLE
Add arb opportunities schema and integration test

### DIFF
--- a/backend/tests/test_tasks_analysis_integration.py
+++ b/backend/tests/test_tasks_analysis_integration.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import types
+import pytest
+
+from app import tasks_analysis as ta
+
+
+def test_compute_opportunities_inserts_dutch_book(monkeypatch):
+    inserted = []
+
+    class FakeTable:
+        def __init__(self, name: str):
+            self.name = name
+        def insert(self, payload):
+            inserted.append(payload)
+            return self
+        def execute(self):
+            return types.SimpleNamespace(data=[{"id": "arb1"}])
+    class FakeSupabase:
+        def table(self, name: str):
+            assert name == "arb_opportunities"
+            return FakeTable(name)
+    monkeypatch.setattr(ta, "supabase", FakeSupabase())
+
+    monkeypatch.setattr(ta, "_load_platform_fees", lambda: {"A": {"taker_bps": 0}, "B": {"taker_bps": 0}})
+    monkeypatch.setattr(ta, "_recent_groups", lambda limit=200: [{"id": "g1", "market_ids": ["m1", "m2"]}])
+    now = ta._now_ts()
+    def latest(mid: str):
+        if mid == "m1":
+            return {"ts": now, "outcomes": [{"label": "YES", "mid": 0.4}, {"label": "NO", "mid": 0.6}], "fees": {"_platform_hint": "A"}}
+        return {"ts": now, "outcomes": [{"label": "YES", "mid": 0.45}, {"label": "NO", "mid": 0.55}], "fees": {"_platform_hint": "B"}}
+    monkeypatch.setattr(ta, "_latest_snapshot", latest)
+    monkeypatch.setattr(ta, "_fillable_usd", lambda snap: 100.0)
+    monkeypatch.setattr(ta, "_fanout_alerts_for_users", lambda *args, **kwargs: 0)
+    orig_build = ta._build_dutch_book
+    monkeypatch.setattr(ta, "_build_dutch_book", lambda g, f: orig_build(g, f, size_candidates=(100.0,)))
+
+    res = ta.compute_opportunities(max_groups=1, write_dutch=True, write_mispricing=False, min_ev_usd_alert=9999)
+    assert res["inserted"] == 1
+    assert len(inserted) == 1
+    row = inserted[0]
+    assert row["opp_type"] == "dutch_book"
+    assert row["metrics"]["ev_usd"] == pytest.approx(5.0)
+    assert row["metrics"]["edge_bps"] == 500

--- a/infra/sql/schema.sql
+++ b/infra/sql/schema.sql
@@ -32,3 +32,42 @@ create table if not exists predictions (
 create index if not exists idx_markets_source_ext on markets(source, external_id);
 create index if not exists idx_predictions_profile on predictions(profile_id);
 
+-- Table storing discovered arbitrage opportunities
+create table if not exists arb_opportunities (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  opp_hash text not null,
+  opp_type text not null,
+  group_id text,
+  legs jsonb not null,
+  params jsonb not null default '{}'::jsonb,
+  metrics jsonb not null default '{}'::jsonb
+);
+
+-- Deduplicate by hash
+create unique index if not exists idx_arb_opportunities_hash on arb_opportunities(opp_hash);
+
+-- Queue for user alerts referencing arbitrage rows
+create table if not exists alerts_queue (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  arb_id uuid references arb_opportunities(id) on delete cascade,
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);
+
+-- Platform level fees used when computing opportunities
+create table if not exists platform_fees (
+  platform text primary key,
+  taker_bps numeric not null,
+  withdrawal_fee_usd numeric not null,
+  gas_estimate_usd numeric not null,
+  updated_at timestamptz not null default now()
+);
+
+-- Seed initial fee settings
+insert into platform_fees (platform, taker_bps, withdrawal_fee_usd, gas_estimate_usd) values
+  ('polymarket', 20, 5, 1),
+  ('limitless', 0, 0, 0)
+on conflict (platform) do nothing;
+


### PR DESCRIPTION
## Summary
- define `arb_opportunities`, `alerts_queue`, and `platform_fees` tables with required fields
- seed `platform_fees` for polymarket and limitless
- add integration test ensuring a Dutch-book is inserted into `arb_opportunities`

## Testing
- `SUPABASE_URL=x SUPABASE_SERVICE_ROLE=y PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4dfad87ac8326bd344f51e6184b40