### PR TITLE
Implement Telegram alert queue processing

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -25,6 +25,7 @@ HEARTBEAT_SEC = int(os.getenv("HEARTBEAT_SEC", "30"))
 # Analysis cadence
 ANALYSIS_COMPUTE_SEC = int(os.getenv("ANALYSIS_COMPUTE_SEC", "90"))
 ANALYSIS_MAX_GROUPS = int(os.getenv("ANALYSIS_MAX_GROUPS", "200"))
+ALERTS_POLL_SEC = int(os.getenv("ALERTS_POLL_SEC", "60"))
 
 # Tunables for batch sizes
 PM_FETCH_LIMIT = int(os.getenv("PM_FETCH_LIMIT", "300"))
@@ -66,6 +67,7 @@ celery.conf.update(
         "grouping.recompute_all": {"queue": "grouping"},
         # Analysis
         "analysis.compute_opportunities": {"queue": "analysis"},
+        "alerts.process_queue": {"queue": "alerts"},
         # Health
         "app.tasks.heartbeat": {"queue": "default"},
     },
@@ -83,6 +85,7 @@ celery.conf.update(
         "app.tasks_embeddings",   # embeddings.embed_new_markets
         "app.tasks_grouping",     # grouping.recompute_all / recompute_for_market
         "app.tasks_analysis",     # analysis.compute_opportunities   <-- added
+        "app.tasks_alerts",       # alerts.process_queue
     ],
 )
 
@@ -150,6 +153,14 @@ celery.conf.beat_schedule = {
         "schedule": ANALYSIS_COMPUTE_SEC,
         "args": (ANALYSIS_MAX_GROUPS,),
         "options": {"queue": "analysis"},
+    },
+
+    # --- Alerts ---
+    "alerts-process-queue": {
+        "task": "alerts.process_queue",
+        "schedule": ALERTS_POLL_SEC,
+        "args": (),
+        "options": {"queue": "alerts"},
     },
 
     # --- Heartbeat / health ---

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -32,6 +32,7 @@ def _safe_import(module_path: str) -> None:
 _safe_import("tasks_ingest")       # ingest.fetch_markets/write_markets/write_snapshots
 _safe_import("tasks_embeddings")   # embeddings.embed_new_markets
 _safe_import("tasks_grouping")     # grouping.recompute_* tasks
+_safe_import("tasks_alerts")       # alerts.process_queue
 
 # Optional: make linters happy by referencing symbols if present.
 # (No runtime effect; tasks are registered by the imports above.)
@@ -45,5 +46,9 @@ except Exception:
     pass
 try:
     from .tasks_embeddings import embed_new_markets  # noqa: F401
+except Exception:
+    pass
+try:
+    from .tasks_alerts import process_alerts_queue  # noqa: F401
 except Exception:
     pass

--- a/backend/app/tasks_alerts.py
+++ b/backend/app/tasks_alerts.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+import os
+import httpx
+
+from .celery_app import celery
+from .db import supabase
+from .settings import settings
+
+log = logging.getLogger(__name__)
+
+ALERT_COOLDOWN_SEC = int(os.getenv("ALERT_COOLDOWN_SEC", "300"))
+ALERT_MIN_EV_CHANGE = float(os.getenv("ALERT_MIN_EV_CHANGE", "1.0"))
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def send_telegram_message(chat_id: str, text: str, token: str | None = None) -> None:
+    """Send a Telegram message using HTTP API."""
+    token = token or settings.telegram_bot_token
+    if not token:
+        log.info("No TELEGRAM_BOT_TOKEN; skipping send")
+        return
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        httpx.post(url, data={"chat_id": chat_id, "text": text}, timeout=10)
+    except Exception as e:  # pragma: no cover - network failure
+        log.warning("Telegram send failed: %s", e)
+
+
+@celery.task(name="alerts.process_queue")
+def process_alerts_queue(limit: int = 100,
+                         cooldown_sec: int = ALERT_COOLDOWN_SEC,
+                         min_ev_change: float = ALERT_MIN_EV_CHANGE) -> Dict[str, Any]:
+    """Process pending alert rows and send Telegram notifications."""
+    if not supabase:
+        log.info("No Supabase client; skipping alerts")
+        return {"sent": 0, "skipped": 0}
+    rows = (
+        supabase
+        .table("alerts_queue")
+        .select("*")
+        .eq("status", "pending")
+        .limit(limit)
+        .execute()
+        .data
+        or []
+    )
+    sent = 0
+    skipped = 0
+    now = _now()
+    for row in rows:
+        arb_id = row.get("arb_id")
+        user_id = row.get("user_id")
+        if not arb_id or not user_id:
+            skipped += 1
+            continue
+        opp = (
+            supabase
+            .table("arb_opportunities")
+            .select("metrics")
+            .eq("id", arb_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if not opp:
+            skipped += 1
+            continue
+        metrics = opp[0].get("metrics") or {}
+        ev = float(metrics.get("ev_usd") or 0.0)
+        last_sent_str = row.get("sent_at") or row.get("last_sent")
+        last_sent = None
+        if last_sent_str:
+            try:
+                last_sent = datetime.fromisoformat(last_sent_str)
+            except Exception:
+                pass
+        last_val = row.get("last_value")
+        if last_sent and (now - last_sent).total_seconds() < cooldown_sec:
+            continue
+        if last_val is not None and abs(ev - float(last_val)) < min_ev_change:
+            continue
+        text = f"Opportunity EV ${ev:.2f}"
+        send_telegram_message(user_id, text)
+        supabase.table("alerts_queue").update({
+            "status": "sent",
+            "sent_at": now.isoformat(),
+            "last_value": ev,
+        }).eq("id", row.get("id")).execute()
+        sent += 1
+    return {"sent": sent, "skipped": skipped}

--- a/backend/tests/test_tasks_alerts.py
+++ b/backend/tests/test_tasks_alerts.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import tasks_alerts as ta
+
+
+class FakeSupabase:
+    def __init__(self, alerts_rows, opps):
+        self.alerts_rows = alerts_rows
+        self.opps = opps
+
+    def table(self, name):
+        if name == "alerts_queue":
+            return FakeAlertsTable(self)
+        if name == "arb_opportunities":
+            return FakeOppTable(self)
+        raise KeyError(name)
+
+
+class FakeAlertsTable:
+    def __init__(self, parent):
+        self.parent = parent
+        self.mode = "select"
+        self.filters = {}
+        self.payload = None
+        self.limit_n = None
+
+    def select(self, *_):
+        self.mode = "select"
+        return self
+
+    def update(self, payload):
+        self.mode = "update"
+        self.payload = payload
+        return self
+
+    def eq(self, col, val):
+        self.filters[col] = val
+        return self
+
+    def limit(self, n):
+        self.limit_n = n
+        return self
+
+    def execute(self):
+        if self.mode == "select":
+            rows = [r for r in self.parent.alerts_rows if all(r.get(k) == v for k, v in self.filters.items())]
+            if self.limit_n is not None:
+                rows = rows[: self.limit_n]
+            return types.SimpleNamespace(data=rows)
+        elif self.mode == "update":
+            for r in self.parent.alerts_rows:
+                if all(r.get(k) == v for k, v in self.filters.items()):
+                    r.update(self.payload)
+            return types.SimpleNamespace(data=[])
+        raise RuntimeError("invalid mode")
+
+
+class FakeOppTable:
+    def __init__(self, parent):
+        self.parent = parent
+        self.filters = {}
+        self.limit_n = None
+
+    def select(self, *_):
+        return self
+
+    def eq(self, col, val):
+        self.filters[col] = val
+        return self
+
+    def limit(self, n):
+        self.limit_n = n
+        return self
+
+    def execute(self):
+        opp = self.parent.opps.get(self.filters.get("id"))
+        rows = [opp] if opp else []
+        return types.SimpleNamespace(data=rows)
+
+
+def test_process_queue_sends_and_updates(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(ta, "_now", lambda: now)
+    alerts = [{"id": "a1", "user_id": "u1", "arb_id": "o1", "status": "pending"}]
+    opps = {"o1": {"metrics": {"ev_usd": 10.0}}}
+    fake = FakeSupabase(alerts, opps)
+    monkeypatch.setattr(ta, "supabase", fake)
+    sent = []
+    monkeypatch.setattr(ta, "send_telegram_message", lambda uid, text, token=None: sent.append((uid, text)))
+    monkeypatch.setattr(ta, "settings", types.SimpleNamespace(telegram_bot_token="T"))
+
+    res = ta.process_alerts_queue(limit=10, cooldown_sec=0, min_ev_change=0)
+    assert res["sent"] == 1
+    assert alerts[0]["status"] == "sent"
+    assert alerts[0]["last_value"] == 10.0
+    assert sent and sent[0][0] == "u1"
+
+
+def test_process_queue_respects_cooldown(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(ta, "_now", lambda: now)
+    alerts = [{
+        "id": "a1",
+        "user_id": "u1",
+        "arb_id": "o1",
+        "status": "pending",
+        "sent_at": (now - timedelta(seconds=30)).isoformat(),
+        "last_value": 5.0,
+    }]
+    opps = {"o1": {"metrics": {"ev_usd": 6.0}}}
+    fake = FakeSupabase(alerts, opps)
+    monkeypatch.setattr(ta, "supabase", fake)
+    sent = []
+    monkeypatch.setattr(ta, "send_telegram_message", lambda *args, **kwargs: sent.append(1))
+    monkeypatch.setattr(ta, "settings", types.SimpleNamespace(telegram_bot_token="T"))
+
+    res = ta.process_alerts_queue(limit=10, cooldown_sec=60, min_ev_change=0)
+    assert res["sent"] == 0
+    assert alerts[0]["status"] == "pending"
+    assert not sent
+
+
+def test_process_queue_requires_value_change(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(ta, "_now", lambda: now)
+    alerts = [{
+        "id": "a1",
+        "user_id": "u1",
+        "arb_id": "o1",
+        "status": "pending",
+        "sent_at": (now - timedelta(seconds=120)).isoformat(),
+        "last_value": 10.0,
+    }]
+    opps = {"o1": {"metrics": {"ev_usd": 10.2}}}
+    fake = FakeSupabase(alerts, opps)
+    monkeypatch.setattr(ta, "supabase", fake)
+    sent = []
+    monkeypatch.setattr(ta, "send_telegram_message", lambda *a, **k: sent.append(1))
+    monkeypatch.setattr(ta, "settings", types.SimpleNamespace(telegram_bot_token="T"))
+
+    res = ta.process_alerts_queue(limit=10, cooldown_sec=60, min_ev_change=1.0)
+    assert res["sent"] == 0
+    assert alerts[0]["status"] == "pending"
+    assert not sent


### PR DESCRIPTION
## Summary
- add `alerts.process_queue` task to send Telegram messages for pending alerts with cooldown and value-change checks
- register alerts task with Celery routes and beat schedule
- cover alerts processing with unit tests

## Testing
- `SUPABASE_URL=x SUPABASE_SERVICE_ROLE=y PYTHONPATH=backend pytest backend/tests/test_tasks_alerts.py`
- `SUPABASE_URL=x SUPABASE_SERVICE_ROLE=y PYTHONPATH=backend pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e6d8f8a08326a0800e360e91ccc8