### PR TITLE
Add Telegram WebApp auth and JWT middleware

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+import hmac
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Dict, Any
+from urllib.parse import parse_qsl
+import jwt
+from pydantic import BaseModel
+from .settings import settings
+
+router = APIRouter()
+
+class InitDataIn(BaseModel):
+    init_data: str
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+def _check_init_data(init_data: str) -> Dict[str, str]:
+    params = dict(parse_qsl(init_data, keep_blank_values=True))
+    hash_val = params.get("hash")
+    if not hash_val:
+        raise HTTPException(status_code=400, detail="missing hash")
+    secret = settings.telegram_webapp_secret
+    if not secret:
+        raise HTTPException(status_code=500, detail="telegram secret not configured")
+    data_pairs = [f"{k}={v}" for k, v in sorted(params.items()) if k != "hash"]
+    data_check_string = "\n".join(data_pairs)
+    calc_hash = hmac.new(secret.encode(), data_check_string.encode(), hashlib.sha256).hexdigest()
+    if calc_hash != hash_val:
+        raise HTTPException(status_code=403, detail="invalid signature")
+    return params
+
+
+def create_jwt(payload: Dict[str, Any], expires_in: int = 300) -> str:
+    to_encode = payload.copy()
+    to_encode["exp"] = datetime.utcnow() + timedelta(seconds=expires_in)
+    return jwt.encode(to_encode, settings.jwt_secret, algorithm="HS256")
+
+
+def verify_jwt(
+    creds: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> Dict[str, Any]:
+    if creds is None:
+        raise HTTPException(status_code=401, detail="missing authorization")
+    token = creds.credentials
+    try:
+        return jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=401, detail="invalid token")
+
+
+@router.post("/auth/telegram_webapp")
+def auth_telegram_webapp(payload: InitDataIn) -> Dict[str, Any]:
+    params = _check_init_data(payload.init_data)
+    user_raw = params.get("user")
+    profile = json.loads(user_raw) if user_raw else {}
+    token = create_jwt({"user": profile})
+    return {"token": token, "profile": profile}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ redis==5.0.8
 celery==5.4.0
 rapidfuzz==3.9.6
 sentence-transformers==3.0.1
+PyJWT==2.9.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,54 @@
+import json
+import json
+import hmac
+import hashlib
+from urllib.parse import urlencode
+
+import os
+import jwt
+from fastapi.testclient import TestClient
+
+
+def make_init_data(user, secret):
+    params = {
+        "auth_date": "111111",
+        "query_id": "test",
+        "user": json.dumps(user),
+    }
+    data_check_string = "\n".join(
+        f"{k}={params[k]}" for k in sorted(params)
+    )
+    params["hash"] = hmac.new(
+        secret.encode(), data_check_string.encode(), hashlib.sha256
+    ).hexdigest()
+    return urlencode(params)
+
+
+def test_telegram_auth_valid_and_invalid(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "http://example.com")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE", "dummy")
+    from app.settings import settings
+    monkeypatch.setattr(settings, "telegram_webapp_secret", "webapp_secret")
+    monkeypatch.setattr(settings, "jwt_secret", "jwt_secret")
+    from app.main import app
+    client = TestClient(app)
+
+    user = {"id": 1, "first_name": "Alice"}
+    init_data = make_init_data(user, "webapp_secret")
+    res = client.post("/auth/telegram_webapp", json={"init_data": init_data})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["profile"]["id"] == 1
+    # token decodes
+    decoded = jwt.decode(data["token"], "jwt_secret", algorithms=["HS256"])
+    assert decoded["user"]["id"] == 1
+
+    bad_params = {
+        "auth_date": "111111",
+        "query_id": "test",
+        "user": json.dumps(user),
+        "hash": "deadbeef",
+    }
+    bad_init = urlencode(bad_params)
+    res_bad = client.post("/auth/telegram_webapp", json={"init_data": bad_init})
+    assert res_bad.status_code == 403


### PR DESCRIPTION
## Summary
- validate Telegram WebApp initData and issue short-lived JWTs
- add auth router and JWT check dependency for protected endpoints
- include tests for valid/invalid Telegram signatures

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ebd6b8d48326b25fbb29f74610bf