### PR TITLE
feat: add webapp routing and theme handling

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,12 +10,16 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^5.0.2",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.10"
   }

--- a/webapp/postcss.config.js
+++ b/webapp/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { NavLink, Outlet } from 'react-router-dom'
 
 declare global {
   interface Window {
@@ -8,27 +9,32 @@ declare global {
 
 export default function App() {
   const [tgUser, setTgUser] = useState<string | null>(null)
-  const [theme, setTheme] = useState<string>('')
 
   useEffect(() => {
     const tg = window.Telegram?.WebApp
     try {
       tg?.ready()
-      setTheme(tg?.colorScheme || '')
+      const params = tg?.themeParams || {}
+      Object.entries(params).forEach(([k, v]: [string, any]) => {
+        document.documentElement.style.setProperty(`--tg-theme-${k.replace(/_/g, '-')}`, v)
+      })
+      if (tg?.colorScheme === 'dark') document.documentElement.classList.add('dark')
+      else document.documentElement.classList.remove('dark')
       const u = tg?.initDataUnsafe?.user
       if (u) setTgUser(`${u.first_name || ''} ${u.last_name || ''}`.trim())
     } catch {}
   }, [])
 
   return (
-    <div style={{ padding: 16 }}>
-      <h1>PredArb WebApp</h1>
-      <p>Telegram user: {tgUser || 'Unknown / Not inside Telegram'}</p>
-      <p>Theme: {theme || 'default'}</p>
-      <p>
-        Backend: <code>{import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'}</code>
-      </p>
-      <p>Env: VITE_TELEGRAM_WEBAPP_BOT_ID = <code>{import.meta.env.VITE_TELEGRAM_WEBAPP_BOT_ID || ''}</code></p>
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">PredArb WebApp</h1>
+      <p className="mb-4">Telegram user: {tgUser || 'Unknown / Not inside Telegram'}</p>
+      <nav className="flex gap-4 mb-4">
+        <NavLink to="/" className="underline">Feed</NavLink>
+        <NavLink to="/explorer" className="underline">Explorer</NavLink>
+        <NavLink to="/settings" className="underline">Settings</NavLink>
+      </nav>
+      <Outlet />
     </div>
   )
 }

--- a/webapp/src/ArbFeed.tsx
+++ b/webapp/src/ArbFeed.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { apiFetch } from './api'
+
+interface Opportunity {
+  id: string
+  name?: string
+}
+
+export default function ArbFeed() {
+  const [ops, setOps] = useState<Opportunity[]>([])
+
+  useEffect(() => {
+    apiFetch('/api/opportunities')
+      .then((r) => r.json())
+      .then((d) => setOps(d))
+      .catch(() => setOps([]))
+  }, [])
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Arbitrage Opportunities</h2>
+      <ul className="list-disc pl-6">
+        {ops.map((o) => (
+          <li key={o.id}>{o.name || o.id}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/webapp/src/Explorer.tsx
+++ b/webapp/src/Explorer.tsx
@@ -1,0 +1,8 @@
+export default function Explorer() {
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Explorer</h2>
+      <p>Search and browse markets and groups.</p>
+    </div>
+  )
+}

--- a/webapp/src/GroupView.tsx
+++ b/webapp/src/GroupView.tsx
@@ -1,0 +1,8 @@
+export default function GroupView() {
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Group View</h2>
+      <p>Probability charts, legs, and simulator will appear here.</p>
+    </div>
+  )
+}

--- a/webapp/src/Settings.tsx
+++ b/webapp/src/Settings.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+export default function Settings() {
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    setTheme(document.documentElement.classList.contains('dark') ? 'dark' : 'light')
+  }, [])
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Settings</h2>
+      <div className="mb-2">
+        <label className="font-semibold">Alerts:</label>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Configure alert preferences.</p>
+      </div>
+      <p>Current theme: {theme}</p>
+    </div>
+  )
+}

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -1,0 +1,32 @@
+let accessToken: string | null = localStorage.getItem('accessToken')
+let refreshToken: string | null = localStorage.getItem('refreshToken')
+
+async function refresh() {
+  if (!refreshToken) return false
+  const resp = await fetch('/auth/refresh', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${refreshToken}` },
+  })
+  if (resp.ok) {
+    const data = await resp.json()
+    accessToken = data.accessToken
+    refreshToken = data.refreshToken
+    if (accessToken) localStorage.setItem('accessToken', accessToken)
+    if (refreshToken) localStorage.setItem('refreshToken', refreshToken)
+    return true
+  }
+  return false
+}
+
+export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = new Headers(init.headers || {})
+  if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+  const resp = await fetch(input, { ...init, headers })
+  if (resp.status !== 401) return resp
+  if (await refresh()) {
+    const retryHeaders = new Headers(init.headers || {})
+    if (accessToken) retryHeaders.set('Authorization', `Bearer ${accessToken}`)
+    return fetch(input, { ...init, headers: retryHeaders })
+  }
+  return resp
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --tg-theme-bg-color: #ffffff;
+  --tg-theme-text-color: #000000;
+}
+
+body {
+  background-color: var(--tg-theme-bg-color);
+  color: var(--tg-theme-text-color);
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,10 +1,29 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
+import ArbFeed from './ArbFeed'
+import GroupView from './GroupView'
+import Explorer from './Explorer'
+import Settings from './Settings'
+import './index.css'
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true, element: <ArbFeed /> },
+      { path: 'group/:id', element: <GroupView /> },
+      { path: 'explorer', element: <Explorer /> },
+      { path: 'settings', element: <Settings /> },
+    ],
+  },
+])
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>
 )
 

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -1,0 +1,8 @@
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- configure React Router with feed, explorer, group and settings pages
- hook Telegram theme params into Tailwind variables and dark mode
- add JWT-aware fetch helper and placeholder page components

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c4ecdc9efc8326abedf07ee0a9b364